### PR TITLE
Add frontmatter parsing support for command files

### DIFF
--- a/src/agents/command_generator.rs
+++ b/src/agents/command_generator.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+pub trait CommandGeneratorTrait {
+    /// Generate command files for this agent
+    /// Returns HashMap of output path -> content
+    fn generate_commands(&self, current_dir: &Path) -> HashMap<PathBuf, String>;
+
+    /// Clean generated command files
+    fn clean_commands(&self, current_dir: &Path) -> Result<()>;
+
+    /// Check if command files are in sync
+    fn check_commands(&self, current_dir: &Path) -> Result<bool>;
+
+    /// Get gitignore patterns for generated commands
+    fn command_gitignore_patterns(&self) -> Vec<String>;
+}

--- a/src/utils/frontmatter.rs
+++ b/src/utils/frontmatter.rs
@@ -1,0 +1,104 @@
+use serde::de::DeserializeOwned;
+
+/// YAML frontmatter delimiter
+#[allow(dead_code)]
+pub const FRONTMATTER_DELIMITER: &str = "---";
+
+/// Result of parsing frontmatter from content
+#[derive(Debug, Clone)]
+pub struct ParsedContent<T> {
+    pub frontmatter: Option<T>,
+    pub body: String,
+    pub raw_content: String,
+}
+
+/// Splits content into raw frontmatter string and body, without parsing YAML.
+/// Returns (frontmatter_str, body) if frontmatter exists, otherwise (None, original content).
+#[allow(dead_code)]
+pub fn split_frontmatter(content: &str) -> (Option<&str>, &str) {
+    let trimmed = content.trim_start();
+
+    if !trimmed.starts_with(FRONTMATTER_DELIMITER) {
+        return (None, content);
+    }
+
+    let mut parts = trimmed.splitn(3, FRONTMATTER_DELIMITER);
+    parts.next(); // Skip empty string before first ---
+
+    let frontmatter_str = match parts.next() {
+        Some(s) => s.trim(),
+        None => return (None, content),
+    };
+
+    let body = match parts.next() {
+        Some(s) => s.trim_start(),
+        None => return (None, content),
+    };
+
+    (Some(frontmatter_str), body)
+}
+
+/// Parses content with optional YAML frontmatter into a typed struct.
+/// Returns ParsedContent with frontmatter (if valid YAML) and body.
+pub fn parse_frontmatter<T: DeserializeOwned>(content: &str) -> ParsedContent<T> {
+    let (frontmatter_str, body) = split_frontmatter(content);
+
+    let frontmatter = frontmatter_str.and_then(|s| serde_yaml::from_str(s).ok());
+
+    ParsedContent {
+        frontmatter,
+        body: body.to_string(),
+        raw_content: content.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestFrontMatter {
+        title: String,
+        #[serde(default)]
+        enabled: bool,
+    }
+
+    #[test]
+    fn test_split_frontmatter_with_frontmatter() {
+        let content = "---\ntitle: Test\n---\nBody content";
+        let (fm, body) = split_frontmatter(content);
+        assert_eq!(fm, Some("title: Test"));
+        assert_eq!(body, "Body content");
+    }
+
+    #[test]
+    fn test_split_frontmatter_without_frontmatter() {
+        let content = "Just body content";
+        let (fm, body) = split_frontmatter(content);
+        assert_eq!(fm, None);
+        assert_eq!(body, "Just body content");
+    }
+
+    #[test]
+    fn test_parse_frontmatter_typed() {
+        let content = "---\ntitle: Hello\nenabled: true\n---\nBody here";
+        let parsed: ParsedContent<TestFrontMatter> = parse_frontmatter(content);
+        assert_eq!(
+            parsed.frontmatter,
+            Some(TestFrontMatter {
+                title: "Hello".to_string(),
+                enabled: true
+            })
+        );
+        assert_eq!(parsed.body, "Body here");
+    }
+
+    #[test]
+    fn test_parse_frontmatter_invalid_yaml() {
+        let content = "---\ninvalid: [unclosed\n---\nBody";
+        let parsed: ParsedContent<TestFrontMatter> = parse_frontmatter(content);
+        assert_eq!(parsed.frontmatter, None);
+        assert_eq!(parsed.body, "Body");
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod file_utils;
+pub mod frontmatter;
 pub mod git_utils;
 pub mod goose_utils;
 pub mod print_utils;


### PR DESCRIPTION
## What?
Adds YAML frontmatter parsing to command files. Commands can now include metadata (allowed-tools, description, model) at the top. The `CommandFile` struct now stores parsed frontmatter, body, and raw content. Also adds `CommandGeneratorTrait` for agent-specific command generation.

## Why?
First PR in a series to add command support. Frontmatter enables structured metadata for commands without cluttering content. This foundation will support agent-specific command configuration and generation.

## How?
Created generic frontmatter parser using serde for type-safe deserialization. Parser splits content into frontmatter and body, handling files without frontmatter gracefully. `find_command_files()` now parses frontmatter during loading.