### PR TITLE
Add Cross.toml for GLIBC 2.28 compatibility

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
+
+[build]
+xargo = false


### PR DESCRIPTION
Ensures Linux binaries are built with GLIBC 2.28 to maintain compatibility 