### PR TITLE
Support HTTP remote servers in MCP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ Create `ai-rules/mcp.json` with your MCP server configurations:
       "env": {
         "ENV_VAR": "${use_environment_variable}"
       }
+    },
+    "remote-server-name": {
+      "type": "http",
+      "url": "https://api.example.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add support for HTTP remote MCP servers with `type: "http"`, `url`, and optional `headers`
- Use `McpServerType` enum for type-safe parsing (addresses review feedback)
- Add comprehensive tests for HTTP configs, mixed configs, and invalid type rejection

## Compatibility
| Agent | Format | Notes |
|-------|--------|-------|
| Claude | ✅ Pass-through | Standard format |
| Cursor | ✅ Pass-through | Standard format |
| Firebender | ✅ Pass-through | Standard format |
| Gemini | ✅ Transformed | Converts to `httpUrl` in `GeminiMcpGenerator` |

## Test plan
- [x] All 281 tests pass
- [x] HTTP server with headers
- [x] Mixed command + HTTP configs
- [x] Invalid type values rejected