### PR TITLE
Improve init command prompt messaging for default vs custom recipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-rules"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -68,11 +68,16 @@ pub fn run_init(current_dir: &Path, init_args: InitArgs) -> Result<()> {
         return Ok(());
     }
 
-    if !init_args.force
-        && !prompt_yes_no(
-            "ai-rules/ already has rules. Run Goose to initialize another rule file? [y/N]: ",
-        )?
-    {
+    let prompt_message = match &recipe_source {
+        RecipeSource::Default => {
+            "ai-rules/ already has rules. Create a new rule file using Goose? [y/N]: "
+        }
+        RecipeSource::Custom(_) => {
+            "ai-rules/ already has rules. Run custom Goose recipe? (Existing files are preserved unless your recipe explicitly modifies them) [y/N]: "
+        }
+    };
+
+    if !init_args.force && !prompt_yes_no(prompt_message)? {
         return Ok(());
     }
 


### PR DESCRIPTION
## Why
Clarify the distinction between default recipe (creates new rule file) and custom recipe (runs custom recipe, which may or may not regenerate the rule file) by providing context-specific prompt messages. This improves UX by guiding users to understand the different behaviors without needing additional documentation.

🤖 Generated with Claude Code