### PR TITLE
Adds config option to disable auto edits of gitignore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,18 @@ Create `ai-rules/ai-rules-config.yaml` in the `ai-rules` directory. Example:
 agents: [claude, cursor, cline] # Generate rules only for these agents
 nested_depth: 2 # Search 2 levels deep for ai-rules/ folders
 gitignore: true # Ignore the generated rules in git
+auto_update_gitignore: true # Allow ai-rules to modify .gitignore (default: true)
 ```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `agents` | list | all agents | List of agents to generate rules for |
+| `nested_depth` | number | 0 | Directory depth to scan for `ai-rules/` folders |
+| `gitignore` | boolean | false | Add generated files to `.gitignore` |
+| `auto_update_gitignore` | boolean | true | Allow ai-rules to modify `.gitignore`. Set to `false` to prevent any `.gitignore` changes (useful for repositories with strict `.gitignore` policies) |
+| `use_claude_skills` | boolean | false | Enable Claude Code skills mode (experimental) |
 
 ### Configuration Precedence
 
@@ -99,7 +110,7 @@ Options are resolved in the following order (highest to lowest priority):
 
 1. **CLI options** - `--agents`, `--nested-depth`, `--no-gitignore`
 2. **Config file** - `ai-rules/ai-rules-config.yaml` (at current working directory)
-3. **Default values** - All agents, depth 0, generated files are NOT git ignored
+3. **Default values** - All agents, depth 0, generated files are NOT git ignored, auto-update of `.gitignore` enabled
 
 ### Experimental Options
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -118,6 +118,7 @@ pub struct ResolvedGenerateArgs {
     pub agents: Option<Vec<String>>,
     pub gitignore: bool,
     pub nested_depth: usize,
+    pub auto_update_gitignore: bool,
 }
 
 #[derive(Debug)]

--- a/src/cli/config_resolution.rs
+++ b/src/cli/config_resolution.rs
@@ -46,10 +46,13 @@ impl GenerateArgs {
             false
         };
 
+        let auto_update_gitignore = config.and_then(|c| c.auto_update_gitignore).unwrap_or(true);
+
         ResolvedGenerateArgs {
             agents,
             gitignore,
             nested_depth: nested_depth.unwrap_or(0),
+            auto_update_gitignore,
         }
     }
 }

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -11,6 +11,7 @@ fn test_generate_args_with_config_cli_priority() {
         no_gitignore: None,
         nested_depth: Some(5),
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args = GenerateArgs {
@@ -35,6 +36,7 @@ fn test_generate_args_with_config_uses_config_when_cli_missing() {
         no_gitignore: None,
         nested_depth: Some(3),
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args = GenerateArgs {
@@ -75,6 +77,7 @@ fn test_generate_args_with_config_partial_config() {
         no_gitignore: None,
         nested_depth: None,
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args = GenerateArgs {
@@ -99,6 +102,7 @@ fn test_nested_depth_args_with_config() {
         no_gitignore: None,
         nested_depth: Some(4),
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args_with_cli = NestedDepthArgs {
@@ -121,6 +125,7 @@ fn test_nested_depth_explicit_zero_overrides_config() {
         no_gitignore: None,
         nested_depth: Some(5),
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args = NestedDepthArgs {
@@ -138,6 +143,7 @@ fn test_status_args_with_config_cli_priority() {
         no_gitignore: None,
         nested_depth: Some(5),
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args = StatusArgs {
@@ -161,6 +167,7 @@ fn test_status_args_with_config_uses_config_when_cli_missing() {
         no_gitignore: None,
         nested_depth: Some(3),
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args = StatusArgs {
@@ -195,6 +202,7 @@ fn test_generate_args_backward_compat_no_gitignore_config() {
         no_gitignore: Some(true),
         nested_depth: None,
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args = GenerateArgs {
@@ -217,6 +225,7 @@ fn test_generate_args_backward_compat_no_gitignore_cli() {
         no_gitignore: None,
         nested_depth: None,
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args = GenerateArgs {
@@ -239,6 +248,7 @@ fn test_generate_args_new_gitignore_flag_overrides_old() {
         no_gitignore: None,
         nested_depth: None,
         use_claude_skills: None,
+        auto_update_gitignore: None,
     };
 
     let args = GenerateArgs {
@@ -251,4 +261,61 @@ fn test_generate_args_new_gitignore_flag_overrides_old() {
     let resolved = args.with_config(Some(&config));
 
     assert!(resolved.gitignore);
+}
+
+#[test]
+fn test_generate_args_auto_update_gitignore_defaults_to_true() {
+    let args = GenerateArgs {
+        agents: None,
+        gitignore: false,
+        no_gitignore: false,
+        nested_depth: None,
+    };
+
+    let resolved = args.with_config(None);
+    assert!(resolved.auto_update_gitignore);
+}
+
+#[test]
+fn test_generate_args_auto_update_gitignore_from_config_true() {
+    let config = config::Config {
+        agents: None,
+        gitignore: None,
+        no_gitignore: None,
+        nested_depth: None,
+        use_claude_skills: None,
+        auto_update_gitignore: Some(true),
+    };
+
+    let args = GenerateArgs {
+        agents: None,
+        gitignore: false,
+        no_gitignore: false,
+        nested_depth: None,
+    };
+
+    let resolved = args.with_config(Some(&config));
+    assert!(resolved.auto_update_gitignore);
+}
+
+#[test]
+fn test_generate_args_auto_update_gitignore_from_config_false() {
+    let config = config::Config {
+        agents: None,
+        gitignore: None,
+        no_gitignore: None,
+        nested_depth: None,
+        use_claude_skills: None,
+        auto_update_gitignore: Some(false),
+    };
+
+    let args = GenerateArgs {
+        agents: None,
+        gitignore: false,
+        no_gitignore: false,
+        nested_depth: None,
+    };
+
+    let resolved = args.with_config(Some(&config));
+    assert!(!resolved.auto_update_gitignore);
 }

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -160,6 +160,7 @@ Test rule content"#;
                 agents: None,
                 gitignore: false,
                 nested_depth: 2,
+                auto_update_gitignore: true,
             },
             false,
         );
@@ -209,6 +210,7 @@ Test rule content"#;
                 ]),
                 gitignore: false,
                 nested_depth: CLEAN_NESTED_DEPTH,
+                auto_update_gitignore: true,
             },
             false,
         );

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -70,6 +70,7 @@ mod tests {
             agents: None,
             gitignore: true,
             nested_depth,
+            auto_update_gitignore: true,
         };
         let generate_result = run_generate(project_path, generate_args, false);
         if let Err(e) = &generate_result {
@@ -148,6 +149,7 @@ mod tests {
             agents: None,
             gitignore: true,
             nested_depth,
+            auto_update_gitignore: true,
         };
         let generate_result = run_generate(project_path, generate_args, false);
         assert!(generate_result.is_ok());

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -401,6 +401,7 @@ Test rule content"#;
                 agents: None,
                 gitignore: false,
                 nested_depth,
+                auto_update_gitignore: true,
             },
             false,
         )
@@ -539,6 +540,7 @@ Test rule content"#;
                 agents: Some(vec!["claude".to_string()]),
                 gitignore: false,
                 nested_depth: NESTED_DEPTH,
+                auto_update_gitignore: true,
             },
             false,
         );
@@ -656,6 +658,7 @@ Test command body"#;
                 agents: Some(vec!["claude".to_string()]),
                 gitignore: false,
                 nested_depth: NESTED_DEPTH,
+                auto_update_gitignore: true,
             },
             false,
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub no_gitignore: Option<bool>,
     pub nested_depth: Option<usize>,
     pub use_claude_skills: Option<bool>,
+    pub auto_update_gitignore: Option<bool>,
 }
 
 pub fn load_config(current_dir: &Path) -> Result<Option<Config>> {
@@ -165,5 +166,52 @@ nested_depth: 2
         assert_eq!(config.no_gitignore, Some(true));
         // New field should be None if not specified
         assert_eq!(config.gitignore, None);
+    }
+
+    #[test]
+    fn test_load_config_with_auto_update_gitignore_true() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+agents: ["claude"]
+auto_update_gitignore: true
+"#;
+        create_config_file(temp_dir.path(), config_content);
+
+        let result = load_config(temp_dir.path()).unwrap();
+        assert!(result.is_some());
+        let config = result.unwrap();
+
+        assert_eq!(config.auto_update_gitignore, Some(true));
+    }
+
+    #[test]
+    fn test_load_config_with_auto_update_gitignore_false() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+agents: ["claude"]
+auto_update_gitignore: false
+"#;
+        create_config_file(temp_dir.path(), config_content);
+
+        let result = load_config(temp_dir.path()).unwrap();
+        assert!(result.is_some());
+        let config = result.unwrap();
+
+        assert_eq!(config.auto_update_gitignore, Some(false));
+    }
+
+    #[test]
+    fn test_load_config_without_auto_update_gitignore_defaults_to_none() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+agents: ["claude"]
+"#;
+        create_config_file(temp_dir.path(), config_content);
+
+        let result = load_config(temp_dir.path()).unwrap();
+        assert!(result.is_some());
+        let config = result.unwrap();
+
+        assert!(config.auto_update_gitignore.is_none());
     }
 }


### PR DESCRIPTION
### Overview

Current rules behavior is generally nice to manage overhauls to ai-rules structure changes in a repo. But as we adopt automated workflows it's helpful to have fine grained controls to reduce edits especially when everything generated has already been git ignored.

### Changes
This adds a config `auto_update_gitignore` value s a shutoff toggle for edits to .gitignore. This is still on by default to keep current behavior.