### PR TITLE
[Skills][2/8] Add skills_generator() to AgentRuleGenerator trait

### DIFF
--- a/src/agents/rule_generator.rs
+++ b/src/agents/rule_generator.rs
@@ -1,5 +1,6 @@
 use crate::agents::command_generator::CommandGeneratorTrait;
 use crate::agents::mcp_generator::McpGeneratorTrait;
+use crate::agents::skills_generator::SkillsGeneratorTrait;
 use crate::models::SourceFile;
 use anyhow::Result;
 use std::collections::HashMap;
@@ -30,6 +31,15 @@ pub trait AgentRuleGenerator {
     }
 
     fn command_generator(&self) -> Option<Box<dyn CommandGeneratorTrait>> {
+        None
+    }
+
+    /// Returns a skills generator for creating user-defined skill symlinks.
+    ///
+    /// Agents that support skills (like Claude, Codex, AMP) should override this
+    /// to return their skills generator. The default returns `None` (no skills support).
+    #[allow(dead_code)]
+    fn skills_generator(&self) -> Option<Box<dyn SkillsGeneratorTrait>> {
         None
     }
 }


### PR DESCRIPTION
## Overview

Added support for skills generators in the agent rule system.

Added a new `skills_generator()` method to the `AgentRuleGenerator` trait that returns an optional `SkillsGeneratorTrait` implementation. This method allows agents to provide a skills generator for creating user-defined skill symlinks. The default implementation returns `None` for now.

### Why make this change?

This change enables support for user-defined skills in compatible agents. By adding this trait method, we establish a standardized way for agents to expose skills functionality, making it easier to implement consistent skills support across different agent types while maintaining backward compatibility with agents that don't support skills.

- [x] Test Binary