### PR TITLE
[Skills][4/8] Implement ExternalSkillsGenerator and wire up agents

### DIFF
--- a/src/agents/amp.rs
+++ b/src/agents/amp.rs
@@ -1,10 +1,12 @@
 use crate::agents::amp_command_generator::AmpCommandGenerator;
 use crate::agents::command_generator::CommandGeneratorTrait;
+use crate::agents::external_skills_generator::ExternalSkillsGenerator;
 use crate::agents::rule_generator::AgentRuleGenerator;
 use crate::agents::single_file_based::{
     check_in_sync, clean_generated_files, generate_agent_file_contents,
 };
-use crate::constants::AGENTS_MD_FILENAME;
+use crate::agents::skills_generator::SkillsGeneratorTrait;
+use crate::constants::{AGENTS_MD_FILENAME, AMP_SKILLS_DIR};
 use crate::models::SourceFile;
 use crate::utils::file_utils::{check_agents_md_symlink, create_symlink_to_agents_md};
 use anyhow::Result;
@@ -58,6 +60,10 @@ impl AgentRuleGenerator for AmpGenerator {
 
     fn command_generator(&self) -> Option<Box<dyn CommandGeneratorTrait>> {
         Some(Box::new(AmpCommandGenerator))
+    }
+
+    fn skills_generator(&self) -> Option<Box<dyn SkillsGeneratorTrait>> {
+        Some(Box::new(ExternalSkillsGenerator::new(AMP_SKILLS_DIR)))
     }
 }
 

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -1,7 +1,9 @@
 use crate::agents::claude_command_generator::ClaudeCommandGenerator;
 use crate::agents::command_generator::CommandGeneratorTrait;
+use crate::agents::external_skills_generator::ExternalSkillsGenerator;
 use crate::agents::mcp_generator::{ExternalMcpGenerator, McpGeneratorTrait};
 use crate::agents::rule_generator::AgentRuleGenerator;
+use crate::agents::skills_generator::SkillsGeneratorTrait;
 use crate::constants::{CLAUDE_MCP_JSON, CLAUDE_SKILLS_DIR, GENERATED_FILE_PREFIX};
 use crate::models::source_file::SourceFile;
 use crate::operations::{
@@ -140,6 +142,12 @@ impl AgentRuleGenerator for ClaudeGenerator {
 
     fn command_generator(&self) -> Option<Box<dyn CommandGeneratorTrait>> {
         Some(Box::new(ClaudeCommandGenerator))
+    }
+
+    fn skills_generator(&self) -> Option<Box<dyn SkillsGeneratorTrait>> {
+        // Return a skills generator for user-defined skills in ai-rules/skills/
+        // This is separate from the existing optional-rules-based skills
+        Some(Box::new(ExternalSkillsGenerator::new(CLAUDE_SKILLS_DIR)))
     }
 }
 

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -1,8 +1,10 @@
+use crate::agents::external_skills_generator::ExternalSkillsGenerator;
 use crate::agents::rule_generator::AgentRuleGenerator;
 use crate::agents::single_file_based::{
     check_in_sync, clean_generated_files, generate_agent_file_contents,
 };
-use crate::constants::AGENTS_MD_FILENAME;
+use crate::agents::skills_generator::SkillsGeneratorTrait;
+use crate::constants::{AGENTS_MD_FILENAME, CODEX_SKILLS_DIR};
 use crate::models::SourceFile;
 use crate::utils::file_utils::{check_agents_md_symlink, create_symlink_to_agents_md};
 use anyhow::Result;
@@ -70,6 +72,10 @@ impl AgentRuleGenerator for CodexGenerator {
         } else {
             Ok(vec![])
         }
+    }
+
+    fn skills_generator(&self) -> Option<Box<dyn SkillsGeneratorTrait>> {
+        Some(Box::new(ExternalSkillsGenerator::new(CODEX_SKILLS_DIR)))
     }
 }
 

--- a/src/agents/external_skills_generator.rs
+++ b/src/agents/external_skills_generator.rs
@@ -1,0 +1,176 @@
+use crate::agents::skills_generator::SkillsGeneratorTrait;
+use crate::operations::skills_reader::{
+    check_skill_symlinks_in_sync, create_skill_symlinks, get_skill_gitignore_patterns,
+    remove_generated_skill_symlinks,
+};
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+pub struct ExternalSkillsGenerator {
+    target_dir: String,
+}
+
+impl ExternalSkillsGenerator {
+    #[allow(dead_code)]
+    pub fn new(target_dir: &str) -> Self {
+        Self {
+            target_dir: target_dir.to_string(),
+        }
+    }
+}
+
+impl SkillsGeneratorTrait for ExternalSkillsGenerator {
+    fn skills_target_dir(&self) -> &str {
+        &self.target_dir
+    }
+
+    fn generate_skills(&self, current_dir: &Path) -> Result<Vec<PathBuf>> {
+        create_skill_symlinks(current_dir, &self.target_dir)
+    }
+
+    fn clean_skills(&self, current_dir: &Path) -> Result<()> {
+        remove_generated_skill_symlinks(current_dir, &self.target_dir)
+    }
+
+    fn check_skills(&self, current_dir: &Path) -> Result<bool> {
+        check_skill_symlinks_in_sync(current_dir, &self.target_dir)
+    }
+
+    fn skills_gitignore_patterns(&self) -> Vec<String> {
+        get_skill_gitignore_patterns(&self.target_dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{AI_RULE_SOURCE_DIR, GENERATED_FILE_PREFIX, SKILLS_DIR, SKILL_FILENAME};
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn create_skill_folder(temp_dir: &Path, skill_name: &str, content: &str) -> PathBuf {
+        let skill_dir = temp_dir
+            .join(AI_RULE_SOURCE_DIR)
+            .join(SKILLS_DIR)
+            .join(skill_name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(skill_dir.join(SKILL_FILENAME), content).unwrap();
+        skill_dir
+    }
+
+    #[test]
+    fn test_external_skills_generator_target_dir() {
+        let generator = ExternalSkillsGenerator::new(".claude/skills");
+        assert_eq!(generator.skills_target_dir(), ".claude/skills");
+    }
+
+    #[test]
+    fn test_external_skills_generator_generate() {
+        let temp_dir = TempDir::new().unwrap();
+        let generator = ExternalSkillsGenerator::new(".claude/skills");
+
+        create_skill_folder(temp_dir.path(), "my-skill", "skill content");
+
+        let result = generator.generate_skills(temp_dir.path());
+        assert!(result.is_ok());
+
+        let symlinks = result.unwrap();
+        assert_eq!(symlinks.len(), 1);
+
+        let symlink_path = temp_dir
+            .path()
+            .join(".claude/skills")
+            .join(format!("{}my-skill", GENERATED_FILE_PREFIX));
+        assert!(symlink_path.is_symlink());
+    }
+
+    #[test]
+    fn test_external_skills_generator_clean() {
+        let temp_dir = TempDir::new().unwrap();
+        let generator = ExternalSkillsGenerator::new(".claude/skills");
+
+        // Create skill and generate symlink
+        create_skill_folder(temp_dir.path(), "my-skill", "skill content");
+        generator.generate_skills(temp_dir.path()).unwrap();
+
+        // Create user skill (real folder, not symlink)
+        let user_skill = temp_dir.path().join(".claude/skills/user-skill");
+        fs::create_dir_all(&user_skill).unwrap();
+        fs::write(user_skill.join(SKILL_FILENAME), "user content").unwrap();
+
+        // Clean
+        generator.clean_skills(temp_dir.path()).unwrap();
+
+        // Generated symlink should be gone
+        let generated = temp_dir
+            .path()
+            .join(".claude/skills")
+            .join(format!("{}my-skill", GENERATED_FILE_PREFIX));
+        assert!(!generated.exists());
+
+        // User skill should remain
+        assert!(user_skill.exists());
+    }
+
+    #[test]
+    fn test_external_skills_generator_check_in_sync() {
+        let temp_dir = TempDir::new().unwrap();
+        let generator = ExternalSkillsGenerator::new(".claude/skills");
+
+        // Create skill
+        create_skill_folder(temp_dir.path(), "my-skill", "skill content");
+
+        // Not in sync before generating
+        let result = generator.check_skills(temp_dir.path()).unwrap();
+        assert!(!result);
+
+        // Generate symlinks
+        generator.generate_skills(temp_dir.path()).unwrap();
+
+        // Now in sync
+        let result = generator.check_skills(temp_dir.path()).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn test_external_skills_generator_check_no_skills() {
+        let temp_dir = TempDir::new().unwrap();
+        let generator = ExternalSkillsGenerator::new(".claude/skills");
+
+        // No skills directory - should be in sync (nothing to do)
+        let result = generator.check_skills(temp_dir.path()).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn test_external_skills_generator_gitignore_patterns() {
+        let generator = ExternalSkillsGenerator::new(".claude/skills");
+        let patterns = generator.skills_gitignore_patterns();
+        assert_eq!(patterns, vec![".claude/skills/ai-rules-generated-*/"]);
+    }
+
+    #[test]
+    fn test_external_skills_generator_different_target_dirs() {
+        // Test Claude target
+        let claude_gen = ExternalSkillsGenerator::new(".claude/skills");
+        assert_eq!(
+            claude_gen.skills_gitignore_patterns(),
+            vec![".claude/skills/ai-rules-generated-*/"]
+        );
+
+        // Test Codex target
+        let codex_gen = ExternalSkillsGenerator::new(".codex/skills");
+        assert_eq!(
+            codex_gen.skills_gitignore_patterns(),
+            vec![".codex/skills/ai-rules-generated-*/"]
+        );
+
+        // Test AMP target
+        let amp_gen = ExternalSkillsGenerator::new(".agents/skills");
+        assert_eq!(
+            amp_gen.skills_gitignore_patterns(),
+            vec![".agents/skills/ai-rules-generated-*/"]
+        );
+    }
+}

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -6,6 +6,7 @@ pub mod codex;
 pub mod command_generator;
 pub mod cursor;
 pub mod cursor_command_generator;
+pub mod external_skills_generator;
 pub mod firebender;
 pub mod gemini;
 pub mod mcp_generator;


### PR DESCRIPTION
## Overview

Adds support for external skills directories in Claude, Codex, and AMP agents through a new `ExternalSkillsGenerator` implementation.

- Created a new `external_skills_generator.rs` module that implements the `SkillsGeneratorTrait`
- Added the `skills_generator()` method to the `AgentRuleGenerator` implementations for:
  - Claude (using `CLAUDE_SKILLS_DIR`)
  - Codex (using `CODEX_SKILLS_DIR`)
  - AMP (using `AMP_SKILLS_DIR`)
- The generator creates symlinks to skills in the AI rules directory, manages cleanup, and provides gitignore patterns

- [x] Test Binary