### PR TITLE
[Skills][6/8] Integrate skills into clean command

### DIFF
--- a/src/operations/cleaner.rs
+++ b/src/operations/cleaner.rs
@@ -59,5 +59,14 @@ pub fn clean_generated_files(
         }
     }
 
+    // Clean skill symlinks
+    for agent in agents {
+        if let Some(tool) = registry.get_tool(agent) {
+            if let Some(skills_gen) = tool.skills_generator() {
+                skills_gen.clean_skills(current_dir)?;
+            }
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Overview

Added functionality to clean up skill symlinks during the `clean` operation while preserving user-created skills.

- Enhanced the `clean_generated_files` function in `operations/cleaner.rs` to clean skill symlinks by calling the `clean_skills` method on each agent's skills generator
- Added two new tests in `commands/clean.rs`:
  - `test_run_clean_removes_skill_symlinks`: Verifies that symlinks to skills are properly removed during cleanup
  - `test_run_clean_preserves_user_skills`: Ensures that user-created skills in the target directory are preserved during cleanup

This change ensures proper cleanup of generated skill symlinks while respecting user-created content. It prevents accumulation of stale symlinks when skills are renamed or removed, while maintaining a separation between generated artifacts and user content.

- [x] Test Binary