### PR TITLE
Add Firebender skills support

### DIFF
--- a/Example/.gitignore
+++ b/Example/.gitignore
@@ -1,13 +1,14 @@
 
 # AI Rules - Generated Files
 **/.agents/commands/*-ai-rules.md
-**/.agents/skills/ai-rules-generated-*/
+**/.agents/skills/ai-rules-generated-*
 **/.claude/commands/ai-rules/
-**/.claude/skills/ai-rules-generated-*/
-**/.codex/skills/ai-rules-generated-*/
+**/.claude/skills/ai-rules-generated-*
+**/.codex/skills/ai-rules-generated-*
 **/.cursor/commands/ai-rules/
 **/.cursor/mcp.json
 **/.cursor/rules/
+**/.firebender/skills/ai-rules-generated-*
 **/.gemini/settings.json
 **/.mcp.json
 **/.roo/mcp.json

--- a/Example/ai-rules/skills/stars-we-prefer/SKILL.md
+++ b/Example/ai-rules/skills/stars-we-prefer/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: stars-we-prefer
+description: Our preferred stars for celestial navigation and astronomical reference
+---
+
+# Stars We Prefer
+
+When referencing stars in this project, these are our 10 preferred choices:
+
+1. **Polaris** - The North Star, essential for navigation and finding true north
+2. **Sirius** - The brightest star in the night sky, located in Canis Major
+3. **Betelgeuse** - A red supergiant in Orion, easily recognizable by its reddish hue
+4. **Vega** - One of the brightest stars visible from Earth, part of the Summer Triangle
+5. **Rigel** - A blue supergiant in Orion, contrasting beautifully with Betelgeuse
+6. **Arcturus** - The brightest star in the northern celestial hemisphere
+7. **Capella** - A bright star in Auriga, actually a system of four stars
+8. **Aldebaran** - The red eye of Taurus, a giant star with an orange-red glow
+9. **Antares** - The heart of Scorpius, a red supergiant rivaling Mars in color
+10. **Deneb** - Part of the Summer Triangle, marking the tail of Cygnus the Swan

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -120,7 +120,7 @@ impl AgentRuleGenerator for ClaudeGenerator {
     fn gitignore_patterns(&self) -> Vec<String> {
         let mut patterns = vec![self.output_filename.clone()];
         if self.skills_mode {
-            patterns.push(format!("{}/{}*/", CLAUDE_SKILLS_DIR, GENERATED_FILE_PREFIX));
+            patterns.push(format!("{}/{}*", CLAUDE_SKILLS_DIR, GENERATED_FILE_PREFIX));
         }
         patterns
     }
@@ -188,7 +188,7 @@ mod tests {
 
         assert_eq!(patterns.len(), 2);
         assert!(patterns.contains(&"CLAUDE.md".to_string()));
-        assert!(patterns.contains(&".claude/skills/ai-rules-generated-*/".to_string()));
+        assert!(patterns.contains(&".claude/skills/ai-rules-generated-*".to_string()));
     }
 
     #[test]

--- a/src/agents/external_skills_generator.rs
+++ b/src/agents/external_skills_generator.rs
@@ -147,7 +147,7 @@ mod tests {
     fn test_external_skills_generator_gitignore_patterns() {
         let generator = ExternalSkillsGenerator::new(".claude/skills");
         let patterns = generator.skills_gitignore_patterns();
-        assert_eq!(patterns, vec![".claude/skills/ai-rules-generated-*/"]);
+        assert_eq!(patterns, vec![".claude/skills/ai-rules-generated-*"]);
     }
 
     #[test]
@@ -156,21 +156,21 @@ mod tests {
         let claude_gen = ExternalSkillsGenerator::new(".claude/skills");
         assert_eq!(
             claude_gen.skills_gitignore_patterns(),
-            vec![".claude/skills/ai-rules-generated-*/"]
+            vec![".claude/skills/ai-rules-generated-*"]
         );
 
         // Test Codex target
         let codex_gen = ExternalSkillsGenerator::new(".codex/skills");
         assert_eq!(
             codex_gen.skills_gitignore_patterns(),
-            vec![".codex/skills/ai-rules-generated-*/"]
+            vec![".codex/skills/ai-rules-generated-*"]
         );
 
         // Test AMP target
         let amp_gen = ExternalSkillsGenerator::new(".agents/skills");
         assert_eq!(
             amp_gen.skills_gitignore_patterns(),
-            vec![".agents/skills/ai-rules-generated-*/"]
+            vec![".agents/skills/ai-rules-generated-*"]
         );
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,6 +13,7 @@ pub const CLAUDE_SKILLS_DIR: &str = ".claude/skills";
 pub const CODEX_SKILLS_DIR: &str = ".codex/skills";
 #[allow(dead_code)]
 pub const AMP_SKILLS_DIR: &str = ".agents/skills";
+pub const FIREBENDER_SKILLS_DIR: &str = ".firebender/skills";
 pub const SKILL_FILENAME: &str = "SKILL.md";
 pub const SKILLS_DIR: &str = "skills";
 

--- a/src/operations/skills_reader.rs
+++ b/src/operations/skills_reader.rs
@@ -215,7 +215,7 @@ pub fn check_skill_symlinks_in_sync(current_dir: &Path, target_dir: &str) -> Res
 /// Returns gitignore patterns for generated skill symlinks
 #[allow(dead_code)]
 pub fn get_skill_gitignore_patterns(target_dir: &str) -> Vec<String> {
-    vec![format!("{}/{}*/", target_dir, GENERATED_FILE_PREFIX)]
+    vec![format!("{}/{}*", target_dir, GENERATED_FILE_PREFIX)]
 }
 
 #[cfg(test)]
@@ -427,7 +427,7 @@ mod tests {
     fn test_get_skill_gitignore_patterns() {
         let patterns = get_skill_gitignore_patterns(".claude/skills");
         assert_eq!(patterns.len(), 1);
-        assert_eq!(patterns[0], ".claude/skills/ai-rules-generated-*/");
+        assert_eq!(patterns[0], ".claude/skills/ai-rules-generated-*");
     }
 
     #[test]


### PR DESCRIPTION
This changeset adds skills generation capability to the Firebender
agent by implementing skills_generator() and adding the necessary
FIREBENDER_SKILLS_DIR constant. Also fixes gitignore patterns across
all skill generators by removing incorrect trailing slashes that
prevented proper pattern matching. Includes an example skill file
for testing.
