### PR TITLE
fix(gemini): use marker instead of name prefix for MCP servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-rules"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Problem

Gemini MCP server names were prefixed with `ai-rules-generated-` to distinguish them from user-configured servers. This breaks MCP tool calls:

- Permission: `mcp__agent-task-queue__run_task`
- Actual server name: `ai-rules-generated-agent-task-queue`
- Result: MCP call `mcp__agent-task-queue__run_task()` doesn't match the server

Other agents (Cursor, Roo, Claude) use `ExternalMcpGenerator` which preserves server names.

## Solution

Use `_aiRulesGenerated: true` marker in the server config instead of prefixing the name:

```json
{
  "mcpServers": {
    "agent-task-queue": {
      "command": "uvx",
      "args": ["agent-task-queue@latest"],
      "_aiRulesGenerated": true
    }
  }
}
```

This allows MCP tools to work correctly while still distinguishing generated from user servers for clean/update operations.

## Changes

- Replace `prefix_server_names()` with `mark_as_generated()`
- Add `is_generated()` helper to check for marker
- Update all tests

## Test plan

- [x] All 16 Gemini tests pass
- [x] `cargo test gemini` passes