### PR TITLE
check skills with optional rules excluding the symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-rules"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -41,11 +41,7 @@ impl AgentRuleGenerator for ClaudeGenerator {
         if output_file.exists() || output_file.is_symlink() {
             fs::remove_file(&output_file)?;
         }
-
-        // Only clean skills if in skills mode
-        if self.skills_mode {
-            claude_skills::remove_generated_skills(current_dir)?;
-        }
+        claude_skills::remove_generated_skills(current_dir)?;
 
         Ok(())
     }


### PR DESCRIPTION
**Summary**
Fix Claude skills status check when both optional rules and user-defined skills are present.

**Changes:**

- Always clean generated skill directories regardless of skills_mode, fixing orphaned directories when switching from use_claude_skills: true to false

- Exclude symlinks when counting generated skill directories in check_skills_in_sync(), so user-defined skill symlinks don't interfere with the optional rules count